### PR TITLE
1 payment option not visible on frontend

### DIFF
--- a/includes/class-mmg-checkout-payment.php
+++ b/includes/class-mmg-checkout-payment.php
@@ -35,6 +35,13 @@ class MMG_Checkout_Payment {
         wp_localize_script('mmg-checkout', 'mmg_checkout_params', array(
             'ajax_url' => admin_url('admin-ajax.php'),
         ));
+
+        // For blocks support
+        wp_localize_script('wc-mmg-payments-blocks', 'mmgCheckoutData', array(
+            'title' => $this->get_option('title'),
+            'description' => $this->get_option('description'),
+            'supports' => $this->supports,
+        ));
     }
 
     public function generate_checkout_url() {

--- a/includes/class-mmg-checkout-payment.php
+++ b/includes/class-mmg-checkout-payment.php
@@ -37,10 +37,11 @@ class MMG_Checkout_Payment {
         ));
 
         // For blocks support
+        $gateway_settings = get_option('woocommerce_mmg_checkout_settings', array());
         wp_localize_script('wc-mmg-payments-blocks', 'mmgCheckoutData', array(
-            'title' => $this->get_option('title'),
-            'description' => $this->get_option('description'),
-            'supports' => $this->supports,
+            'title' => isset($gateway_settings['title']) ? $gateway_settings['title'] : 'MMG Checkout',
+            'description' => isset($gateway_settings['description']) ? $gateway_settings['description'] : 'Pay with MMG Checkout',
+            'supports' => array('products', 'refunds'),
         ));
     }
 

--- a/includes/class-wc-mmg-gateway.php
+++ b/includes/class-wc-mmg-gateway.php
@@ -13,6 +13,12 @@ class WC_MMG_Gateway extends WC_Payment_Gateway {
         $this->title = $this->get_option('title');
         $this->description = $this->get_option('description');
 
+        $this->supports = array(
+            'products',
+            'refunds',
+            'checkout_block_support',
+        );
+
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_receipt_' . $this->id, array($this, 'receipt_page'));
     }

--- a/includes/class-wc-mmg-payments-blocks.php
+++ b/includes/class-wc-mmg-payments-blocks.php
@@ -1,0 +1,32 @@
+<?php
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+class WC_MMG_Payments_Blocks extends AbstractPaymentMethodType {
+    protected $name = 'mmg_checkout';
+
+    public function initialize() {
+        $this->settings = get_option('woocommerce_mmg_checkout_settings', array());
+    }
+
+    public function is_active() {
+        return ! empty($this->settings['enabled']) && 'yes' === $this->settings['enabled'];
+    }
+
+    public function get_payment_method_script_handles() {
+        wp_register_script(
+            'wc-mmg-payments-blocks',
+            plugins_url('js/mmg-checkout-blocks.js', dirname(__FILE__)),
+            array('wc-blocks-registry', 'wc-settings', 'wp-element', 'wp-html-entities', 'wp-i18n'),
+            filemtime(plugin_dir_path(dirname(__FILE__)) . 'js/mmg-checkout-blocks.js'),
+            true
+        );
+        return array('wc-mmg-payments-blocks');
+    }
+
+    public function get_payment_method_data() {
+        return array(
+            'title' => $this->settings['title'],
+            'description' => $this->settings['description'],
+        );
+    }
+}

--- a/js/mmg-checkout-blocks.js
+++ b/js/mmg-checkout-blocks.js
@@ -1,0 +1,23 @@
+const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+const { createElement } = window.wp.element;
+const { decodeEntities } = window.wp.htmlEntities;
+
+const MMGCheckoutLabel = ({ title }) => {
+    return createElement('span', {}, decodeEntities(title));
+};
+
+const MMGCheckoutContent = ({ description }) => {
+    return createElement('p', {}, decodeEntities(description));
+};
+
+registerPaymentMethod({
+    name: 'mmg_checkout',
+    label: createElement(MMGCheckoutLabel, { title: mmgCheckoutData.title }),
+    content: createElement(MMGCheckoutContent, { description: mmgCheckoutData.description }),
+    edit: createElement(MMGCheckoutContent, { description: mmgCheckoutData.description }),
+    canMakePayment: () => true,
+    ariaLabel: decodeEntities(mmgCheckoutData.title),
+    supports: {
+        features: mmgCheckoutData.supports,
+    },
+});

--- a/main.php
+++ b/main.php
@@ -22,3 +22,17 @@ if (MMG_Dependency_Checker::check_dependencies()) {
     }
     add_action('plugins_loaded', 'mmg_checkout_init');
 }
+
+add_action('woocommerce_blocks_loaded', 'mmg_checkout_register_block_support');
+
+function mmg_checkout_register_block_support() {
+    if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
+        require_once plugin_dir_path(__FILE__) . 'includes/class-wc-mmg-payments-blocks.php';
+        add_action(
+            'woocommerce_blocks_payment_method_type_registration',
+            function(Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+                $payment_method_registry->register(new WC_MMG_Payments_Blocks());
+            }
+        );
+    }
+}


### PR DESCRIPTION
The plugin lacked support for block-based checkout introduced in WooCommerce 8.3

This change reworks it to support that.

Fix pointed out by Jay Carter