### PR TITLE
add mbstring notice

### DIFF
--- a/includes/class-mmg-dependency-checker.php
+++ b/includes/class-mmg-dependency-checker.php
@@ -9,6 +9,10 @@ class MMG_Dependency_Checker {
             add_action('admin_notices', array(__CLASS__, 'woocommerce_missing_notice'));
             return false;
         }
+        if (!self::is_mbstring_installed()) {
+            add_action('admin_notices', array(__CLASS__, 'mbstring_missing_notice'));
+            return false;
+        }
         return true;
     }
 
@@ -16,10 +20,22 @@ class MMG_Dependency_Checker {
         return in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')));
     }
 
+    private static function is_mbstring_installed() {
+        return extension_loaded('mbstring');
+    }
+
     public static function woocommerce_missing_notice() {
         ?>
         <div class="error">
             <p><?php _e('MMG Checkout requires WooCommerce to be installed and active. Please install and activate WooCommerce to use this plugin.', 'mmg-checkout'); ?></p>
+        </div>
+        <?php
+    }
+
+    public static function mbstring_missing_notice() {
+        ?>
+        <div class="error">
+            <p><?php _e('MMG Checkout requires the mbstring PHP extension to be installed and active on the server. Please install and activate mbstring to use this plugin.', 'mmg-checkout'); ?></p>
         </div>
         <?php
     }


### PR DESCRIPTION
PHP extenstion mbstring is required for token decryption so it must be installed and active on the server. 

An error notice is thrown if it is not.