### PR TITLE
Update checkout URL and allowed hosts for payment processing

### DIFF
--- a/admin/js/mmg-checkout.js
+++ b/admin/js/mmg-checkout.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function ($) {
 function isValidUrl(url) {
   try {
     const parsedUrl = new URL(url);
-    const allowedHosts = ["qpass.com"];
+    const allowedHosts = ["qpass.com", "mmgtest.net"];
     const hostnameWithoutPort = parsedUrl.hostname.split(":")[0]; // Remove port number if present
     const isValid =
       ["https:", "http:"].includes(parsedUrl.protocol) &&

--- a/admin/js/mmg-checkout.js
+++ b/admin/js/mmg-checkout.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function ($) {
 function isValidUrl(url) {
   try {
     const parsedUrl = new URL(url);
-    const allowedHosts = ["qpass.com", "mmgtest.net"];
+    const allowedHosts = ["qpass.com", "mmgtest.net", "mymmg.gy"];
     const hostnameWithoutPort = parsedUrl.hostname.split(":")[0]; // Remove port number if present
     const isValid =
       ["https:", "http:"].includes(parsedUrl.protocol) &&

--- a/admin/js/mmg-checkout.js
+++ b/admin/js/mmg-checkout.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function ($) {
 function isValidUrl(url) {
   try {
     const parsedUrl = new URL(url);
-    const allowedHosts = ["qpass.com", "mmgtest.net", "mymmg.gy"];
+    const allowedHosts = ["mmgtest.net", "mymmg.gy"];
     const hostnameWithoutPort = parsedUrl.hostname.split(":")[0]; // Remove port number if present
     const isValid =
       ["https:", "http:"].includes(parsedUrl.protocol) &&

--- a/devbox.lock
+++ b/devbox.lock
@@ -6,9 +6,41 @@
       "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#caddy",
       "source": "nixpkg"
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2025-11-26T06:22:50Z",
+      "resolved": "github:NixOS/nixpkgs/bb813de6d2241bcb1b5af2d3059f560c66329967?lastModified=1764138170&narHash=sha256-2bCmfCUZyi2yj9FFXYKwsDiaZmizN75cLhI%2FeWmf3tk%3D"
+    },
+    "glibcLocales@latest": {
+      "last_modified": "2025-11-23T21:50:36Z",
+      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#glibcLocales",
+      "source": "devbox-search",
+      "version": "2.40-66",
+      "systems": {
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lhf8phvkgmlqr5ys1bgfr4g38b3l95kd-glibc-locales-2.40-66",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lhf8phvkgmlqr5ys1bgfr4g38b3l95kd-glibc-locales-2.40-66"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hjlkypp9lpxwzsjycpy7nqg2mnl7qhzv-glibc-locales-2.40-66",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hjlkypp9lpxwzsjycpy7nqg2mnl7qhzv-glibc-locales-2.40-66"
+        }
+      }
+    },
     "mysql80@latest": {
       "last_modified": "2024-09-10T15:01:03Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#mysql80",
       "source": "devbox-search",
       "version": "8.0.39",

--- a/includes/class-mmg-checkout-payment.php
+++ b/includes/class-mmg-checkout-payment.php
@@ -440,8 +440,8 @@ class MMG_Checkout_Payment {
 		}
 
 		$order_id       = $this->extract_order_id( $payment_data['merchantTransactionId'] );
-		$result_code    = isset( $payment_data['resultCode'] ) ? intval( $payment_data['resultCode'] ) : null;
-		$result_message = isset( $payment_data['resultMessage'] ) ? sanitize_text_field( $payment_data['resultMessage'] ) : '';
+		$result_code    = isset( $payment_data['ResultCode'] ) ? intval( $payment_data['ResultCode'] ) : null;
+		$result_message = isset( $payment_data['ResultMessage'] ) ? sanitize_text_field( $payment_data['ResultMessage'] ) : '';
 
 		$order = wc_get_order( $order_id );
 

--- a/includes/class-mmg-checkout-payment.php
+++ b/includes/class-mmg-checkout-payment.php
@@ -543,11 +543,12 @@ class MMG_Checkout_Payment {
 		}
 
 		$option_name = 'mmg_' . $mode . '_checkout_url';
+		
 		$default_url = 'live' === $mode
 			? 'https://gtt-checkout.qpass.com:8743/checkout-endpoint/home'
-			: 'https://gtt-uat-checkout.qpass.com:8743/checkout-endpoint/home';
+			: 'https://mmgpg.mmgtest.net/mmg-pg/web/payments';
 
-			return get_option( $option_name, $default_url );
+		return get_option( $option_name, $default_url );
 	}
 
 	/**

--- a/includes/class-mmg-checkout-payment.php
+++ b/includes/class-mmg-checkout-payment.php
@@ -545,7 +545,7 @@ class MMG_Checkout_Payment {
 		$option_name = 'mmg_' . $mode . '_checkout_url';
 		
 		$default_url = 'live' === $mode
-			? 'https://gtt-checkout.qpass.com:8743/checkout-endpoint/home'
+			? 'https://mmgpg.mymmg.gy/mmg-pg/web/payments'
 			: 'https://mmgpg.mmgtest.net/mmg-pg/web/payments';
 
 		return get_option( $option_name, $default_url );

--- a/main.php
+++ b/main.php
@@ -11,7 +11,7 @@
  * Plugin Name:       MMG Checkout Payment
  * Plugin URI:        https://mmg-plugin.kalpa.dev
  * Description:       Enables MMG Checkout Payment flow for registered MMG Merchants to receive E-Commerce payments from MMG customers.
- * Version:           2.1.8
+ * Version:           2.1.9
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            Kalpa Services Inc.


### PR DESCRIPTION
This pull request updates the MMG Checkout Payment plugin to version 2.1.9 and makes several important changes to support new environments and improve compatibility with updated payment data formats. The main updates include expanding allowed hosts, updating payment gateway URLs, and correcting payment data handling for result codes and messages.

**Environment and URL updates:**
* Expanded the list of allowed hosts in the `isValidUrl` function to include `mmgtest.net` and `mymmg.gy`.
* Updated default checkout URLs in `get_checkout_url` to use new MMG endpoints (`mmgpg.mymmg.gy` for live and `mmgpg.mmgtest.net` for test) instead of the old `qpass.com` URLs.

**Payment data handling improvements:**
* Changed the handling of payment data in `handle_payment_confirmation` to use `ResultCode` and `ResultMessage` keys (with correct casing), ensuring compatibility with the latest payment gateway response format.