### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/admin/js/admin-script.js
+++ b/admin/js/admin-script.js
@@ -313,7 +313,7 @@ jQuery(document).ready(function ($) {
               html += '<span class="mmg-log-badge mmg-log-badge-' + entry.lvl + '">' + entry.lvl_upper + "</span>";
               html += '<span class="mmg-log-time">' + entry.dt + "</span>";
               html += '<span class="mmg-log-msg">' + entry.msg + "</span>";
-              html += '<button type="button" class="mmg-log-copy" title="Copy" onclick="mmgCopyToClipboard(\'' + entry.copy.replace(/'/g, "\\'") + "')\">";
+              html += '<button type="button" class="mmg-log-copy" title="Copy" onclick="mmgCopyToClipboard(' + JSON.stringify(String(entry.copy)) + ')">';
               html += '<span class="dashicons dashicons-clipboard"></span>';
               html += "</button>";
               html += "</div>";


### PR DESCRIPTION
Potential fix for [https://github.com/Kalpa-Services/mmg-wp-plugin/security/code-scanning/6](https://github.com/Kalpa-Services/mmg-wp-plugin/security/code-scanning/6)

General fix: stop manually escaping only one metacharacter and use robust encoding for the exact target context (here, JavaScript string literal embedded in HTML attribute JS code).

Best fix in this snippet (without changing behavior): in `admin/js/admin-script.js`, where line 316 builds the inline `onclick`, replace the manual `entry.copy.replace(...)` with `JSON.stringify(String(entry.copy))`. This safely escapes backslashes, quotes, control characters, etc., and produces a valid JS string literal argument for `mmgCopyToClipboard(...)`.

Concretely:
- File: `admin/js/admin-script.js`
- Region: inside `logs.forEach(function (entry) { ... })`, the line building the copy button `onclick`.
- Change only that line; no new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
